### PR TITLE
Tweak status colors to match convention for Transmission

### DIFF
--- a/src/views/components/Torrent.vue
+++ b/src/views/components/Torrent.vue
@@ -113,7 +113,7 @@ export default defineComponent({
     }
   },
   setup() {
-    const ProgressBarColors = ["medium","warning","warning","medium","success",null,"primary"];
+    const ProgressBarColors = ["medium","medium","warning","medium","primary","medium","success"];
 
     return { 
       Locale,


### PR DESCRIPTION
Basically, blue is downloading and green is seeding. Right now, Transmissionic does the opposite and it's confusing.

Fixes #1391 