### PR TITLE
fix: ensure magnet link is string before parsing

### DIFF
--- a/src/services/FileHandler.ts
+++ b/src/services/FileHandler.ts
@@ -169,10 +169,11 @@ export const FileHandler = {
     const magnets: Array<any> = [];
     for(const magnet of list){
       try {
-        const data = await parseTorrent(magnet);
+        const magnetStr = typeof magnet === 'string' ? magnet : String(magnet);
+        const data = await parseTorrent(magnetStr);
         magnets.push({
           data,
-          torrent:magnet
+          torrent: magnetStr
         });
       } catch (error: any) {
         Utils.responseToast(error.message);


### PR DESCRIPTION
## Summary

Fixes #1384

## Problem

When adding certain magnet links, `parseTorrent()` throws `t.charCodeAt is not a function`. This happens because in some edge cases (e.g. drag-and-drop, protocol handler callbacks), the magnet value passed to `readMagnets()` may not be a plain string.

## Fix

Added explicit string coercion before passing the value to `parseTorrent()`:

```ts
const magnetStr = typeof magnet === 'string' ? magnet : String(magnet);
```

Closes #1384