### PR TITLE
fix: correct progress bar color for seed queued status

### DIFF
--- a/src/views/components/Torrent.vue
+++ b/src/views/components/Torrent.vue
@@ -113,7 +113,7 @@ export default defineComponent({
     }
   },
   setup() {
-    const ProgressBarColors = ["medium","warning","warning","medium","success",null,"primary"];
+    const ProgressBarColors = ["medium","warning","warning","medium","success","primary","primary"];
 
     return { 
       Locale,


### PR DESCRIPTION
## Summary

Fixes #1392

## Problem

Status 5 (seed queued) had `null` as its progress bar color in `ProgressBarColors`, causing the progress bar to render with no color.

## Fix

Changed `null` to `"primary"` to match Transmission's official convention where both seeding and seed-queued states use the primary color.

```ts
// Before
const ProgressBarColors = ["medium","warning","warning","medium","success",null,"primary"];
// After
const ProgressBarColors = ["medium","warning","warning","medium","success","primary","primary"];
```

Closes #1392